### PR TITLE
Typo fixed

### DIFF
--- a/translations/xbmc-main/merged-langfiles/language/German/strings.po
+++ b/translations/xbmc-main/merged-langfiles/language/German/strings.po
@@ -12139,7 +12139,7 @@ msgstr "Test Muster zur Bildschirm-Hardware Kalibrierung."
 
 msgctxt "#36359"
 msgid "Use limited colour range (16-235) instead of full colour range (0-255). Limited range should be used if your display is a regular HDMI TV and doesn't have a PC or other mode to display full range colour, however if your display is a PC monitor then leave this disabled to get proper blacks."
-msgstr "Nutzt einen eingeschränkten Farbraum (16-235) anstelle des vollen Bereiches (0-255). Der eingeschränkte Farmraum sollte verwendet werden, wenn XBMC an einem HDMI TV ohne PC-Modus bzw. ohne vollen Farbraum verwendet wird. Wenn ein PC Monitor verwendet wird, sollte diese Einstellung deaktiviert bleiben, um ein korrektes Schwarz zu erhalten."
+msgstr "Nutzt einen eingeschränkten Farbraum (16-235) anstelle des vollen Bereiches (0-255). Der eingeschränkte Farbraum sollte verwendet werden, wenn XBMC an einem HDMI TV ohne PC-Modus bzw. ohne vollen Farbraum verwendet wird. Wenn ein PC Monitor verwendet wird, sollte diese Einstellung deaktiviert bleiben, um ein korrektes Schwarz zu erhalten."
 
 msgctxt "#36360"
 msgid "Category containing settings for how audio output is handled."


### PR DESCRIPTION
It is 'Farbraum' http://www.dict.cc/?s=farbraum  

Since the change is hard to spot in line diff view:

[..] Der eingeschränkte **FarMraum** sollte verwendet werde [..]
[..] Der eingeschränkte **FarBraum** sollte verwendet werde [..]
