### PR TITLE
/Jakso/Idästä/

### DIFF
--- a/translations/xbmc-skins/merged-langfiles/skin.amber/language/Finnish/strings.po
+++ b/translations/xbmc-skins/merged-langfiles/skin.amber/language/Finnish/strings.po
@@ -302,7 +302,7 @@ msgstr "Näytteet"
 
 msgctxt "#31973"
 msgid "E"
-msgstr "Idästä"
+msgstr "Jakso"
 
 msgctxt "#31974"
 msgid "Home menu"


### PR DESCRIPTION
"Idästä" is wrong. For example, at the moment Kodi is showing "Idästä1.1" when watching tv show Episode 1 of Season 1. 

"Jakso" makes more sense in this case, which literally means "Episode".